### PR TITLE
Reorient method to keep all but one component positive on average

### DIFF
--- a/tfac/tensor.py
+++ b/tfac/tensor.py
@@ -46,6 +46,7 @@ def reorient_factors(factors):
 
 #### Decomposition Methods ###################################################################
 
+
 def cp_decomp(tensor, r, nneg=False):
     """Perform PARAFAC decomposition.
     -----------------------------------------------
@@ -79,11 +80,14 @@ def tucker_decomp(tensor, rank_list, nneg=False):
         output = tucker(tensor, rank_list, tol=1.0e-10, n_iter_max=2000)
     return output
 
+
 #### For R2X Plots ###########################################################################
+
 
 def find_R2X_parafac(cp_output, orig):
     """Compute R2X for the tucker decomposition."""
     return R2X(tl.kruskal_to_tensor(cp_output), orig)
+
 
 def find_R2X_tucker(tucker_output, orig):
     """Compute R2X for the tucker decomposition."""


### PR DESCRIPTION
This reorients all but the last factor to be positive on average. @robthemike1, if you hook this into the figure building code, I believe it should work (it's from another project with some slight adjustments).