### PR TITLE
Cycif reorganized into 4 dim array

### DIFF
--- a/tfac/dataHelpers.py
+++ b/tfac/dataHelpers.py
@@ -132,7 +132,7 @@ def import_LINCS_MEMA(datafile):
 
 def Tensor_LINCS_CycIF():
     """ Imports the cyclic immunofluorescence data from LINCS. """
-    data = pd.read_csv(join(path_here, "tfac/data/CycIF/MDD_cycIF_Level4.csv"), delimiter=",", index_col=0)
+    data = pd.read_csv(join(path_here, "tfac/data/CycIF/MDD_cycIF_Level4.csv"), delimiter=",", index_col=0) # data size: 660 x 36
 
     ctrl = data['ctrl_0']
     data.drop(columns='ctrl_0', inplace=True)
@@ -150,10 +150,21 @@ def Tensor_LINCS_CycIF():
     data = data.loc[:, data.dtypes == float]
     data.iloc[:, :] = scale(data)
 
-    datat = data.T
-    datat.index = datat.index.str.split('_', expand=True)
-    datat = datat.sort_index(level=0)
-    # xdf = data.to_xarray().to_array()
-    # xadf = xdf.rename({"level_0": "treatment", "level_1": "time", "variable": "measurements"})
-    # return xadf
-    return data
+    data.index = pd.MultiIndex.from_tuples(data.index, names=["treatment", "time"]) # 42 x 660
+
+    # a function to only split a string at a specific underscore; in this case we split at the third underscore
+    def split_at(string, n):
+        words = string.split('_')
+        return '_'.join(words[:n]), '_'.join(words[n:])
+
+    # split the data by staining and measurements
+
+    new_cols = []
+    for col in data.columns:
+        new_cols.append(split_at(col, 3))
+    data.columns = pd.MultiIndex.from_tuples(new_cols, names=["stains", "measures"])
+
+    data = data.T.unstack(level=0)
+    xdf = data.T.to_xarray().to_array(dim='measures')
+
+    return xdf

--- a/tfac/dataHelpers.py
+++ b/tfac/dataHelpers.py
@@ -130,7 +130,7 @@ def import_LINCS_MEMA(datafile):
     xdf = data.to_xarray().to_array(dim="Measurement")
     return xdf
 
-def import_LINCS_CycIF():
+def Tensor_LINCS_CycIF():
     """ Imports the cyclic immunofluorescence data from LINCS. """
     data = pd.read_csv(join(path_here, "tfac/data/CycIF/MDD_cycIF_Level4.csv"), delimiter=",", index_col=0)
 
@@ -150,6 +150,10 @@ def import_LINCS_CycIF():
     data = data.loc[:, data.dtypes == float]
     data.iloc[:, :] = scale(data)
 
-    xdf = data.to_xarray().to_array()
-    xadf = xdf.rename({"level_0": "treatment", "level_1": "time", "variable": "measurements"})
-    return xadf
+    datat = data.T
+    datat.index = datat.index.str.split('_', expand=True)
+    datat = datat.sort_index(level=0)
+    # xdf = data.to_xarray().to_array()
+    # xadf = xdf.rename({"level_0": "treatment", "level_1": "time", "variable": "measurements"})
+    # return xadf
+    return data

--- a/tfac/dataHelpers.py
+++ b/tfac/dataHelpers.py
@@ -165,6 +165,6 @@ def Tensor_LINCS_CycIF():
     data.columns = pd.MultiIndex.from_tuples(new_cols, names=["stains", "measures"])
 
     data = data.T.unstack(level=0)
-    xdf = data.T.to_xarray().to_array(dim='measures')
+    xdf = data.T.to_xarray().to_array('measures')
 
     return xdf

--- a/tfac/figures/figure1.py
+++ b/tfac/figures/figure1.py
@@ -6,7 +6,7 @@ from .common import subplotLabel, getSetup
 from tensorly.decomposition import parafac
 from tensorpack import Decomposition, perform_CP
 from tensorpack.plot import tfacr2x, reduction
-from ..dataHelpers import import_LINCS_CCLE, import_LINCS_MEMA, import_LINCS_CycIF
+from ..dataHelpers import import_LINCS_CCLE, import_LINCS_MEMA, Tensor_LINCS_CycIF
 
 
 def makeFigure():
@@ -65,7 +65,7 @@ def makeFigure():
     ax[10].set_xticks([256, 1024, 2048, 8192, 32768])
 
     # mema CycIF
-    CycIF = import_LINCS_CycIF()
+    CycIF = Tensor_LINCS_CycIF()
     th = Decomposition(CycIF.to_numpy(), max_rr=7, method=ppfac)
     th.perform_tfac()
     th.perform_PCA(flattenon=0)

--- a/tfac/figures/figure6.py
+++ b/tfac/figures/figure6.py
@@ -17,17 +17,18 @@ def getsetup(figsize):
     sns.set(style="whitegrid", font_scale=0.7, color_codes=True, palette="colorblind", rc={"grid.linestyle": "dotted", "axes.linewidth": 0.6})
     fig = plt.figure(figsize=figsize, constrained_layout=True)
 
-    gs = fig.add_gridspec(2, 6)
+    gs = fig.add_gridspec(3, 4)
     ax1 = fig.add_subplot(gs[0, :])
     ax2 = fig.add_subplot(gs[1, 0])
     ax3 = fig.add_subplot(gs[1, 1])
-    return ([ax1, ax2, ax3], fig)
+    ax4 = fig.add_subplot(gs[2, :])
+    return ([ax1, ax2, ax3, ax4], fig)
 
 
 def makeFigure():
     """ Get a list of the axis objects and create a figure. """
     # Get list of axis objects
-    ax, f = getsetup((30, 8))
+    ax, f = getSetup((12, 12), (4, 1))
 
     tensor = Tensor_LINCS_CycIF()
     fac = parafac(tensor.to_numpy(), 5, n_iter_max=2000, linesearch=True, tol=1e-9)
@@ -37,7 +38,7 @@ def makeFigure():
     labels = [f"Cmp. {i}" for i in np.arange(1, fac.factors[0].shape[1] + 1)]
     print("R2X: ", 1.0 - np.linalg.norm(tl.cp_to_tensor(fac) - tensor)**2.0 / np.linalg.norm(tensor)**2.0)
 
-    for i in range(2):
+    for i in [0, 1, 3]:
         facZero = pd.DataFrame(fac.factors[i], columns=labels, index=tensor.coords[tensor.dims[i]])
         facZero = reorder_table(facZero)
         g1 = sns.heatmap(facZero.T, ax=ax[i], cmap="PRGn", center=0)

--- a/tfac/figures/figure6.py
+++ b/tfac/figures/figure6.py
@@ -8,7 +8,7 @@ from tensorly.decomposition import parafac
 from tensorpack.cmtf import cp_normalize
 import seaborn as sns
 import matplotlib.pyplot as plt
-from ..dataHelpers import import_LINCS_CycIF, reorder_table
+from ..dataHelpers import Tensor_LINCS_CycIF, reorder_table
 from ..plotHelpers import plot_heatmaps
 from .common import getSetup, subplotLabel
 
@@ -29,7 +29,7 @@ def makeFigure():
     # Get list of axis objects
     ax, f = getsetup((30, 8))
 
-    tensor = import_LINCS_CycIF()
+    tensor = Tensor_LINCS_CycIF()
     fac = parafac(tensor.to_numpy(), 5, n_iter_max=2000, linesearch=True, tol=1e-9)
     fac = cp_flip_sign(fac, 2)
     fac = cp_normalize(fac)


### PR DESCRIPTION
I realized that "measurements" in the CycIF data, were further categorizable! There are 20 measurements (e.g., int_mean_centcyto, txt_standev_plasmem, ...) for 33 staining (?) (e.g., cateninbeta_4, cjun_9, ...)
So instead of a three dimensional tensor(treatment x time x measurements) I made a 4 dimensional tensor (treatment x time x stains x measures).
Here is the R2X plot and the components:
![image](https://user-images.githubusercontent.com/34812750/160505784-6deaaade-58f0-48a8-a4e4-6848a25665cb.png)

![image](https://user-images.githubusercontent.com/34812750/160505836-07b24a0e-7b4f-4850-acfb-74aee0eb06db.png)

![image](https://user-images.githubusercontent.com/34812750/160505860-3c84593d-06d2-4c78-bba5-33d21a6aca0e.png)
